### PR TITLE
Update application.h (int type overflow)

### DIFF
--- a/Open_Theremin_V3/application.h
+++ b/Open_Theremin_V3/application.h
@@ -33,7 +33,7 @@ class Application {
 
     
 #if SERIAL_ENABLED    
-    static const int BAUD = 115200;
+    static const long BAUD = 115200;
 #endif
 
     AppState _state;


### PR DESCRIPTION
Get a compilation error when activating SERIAL_ENABLED:

In file included from D:\Arduino\Project - Theremin\OpenTheremin_V3-master\Open_Theremin_V3\Open_Theremin_V3.ino:69:0:
sketch\application.h:36:29: warning: overflow in implicit constant conversion [-Woverflow]
     static const int BAUD = 115200;

--> value 115200 is too big for 'int' type, must be 'long' instead.